### PR TITLE
Fix collision detection

### DIFF
--- a/src/pong.js
+++ b/src/pong.js
@@ -133,8 +133,11 @@ class Pong
     }
     collide(player, ball)
     {
-        if (player.left < ball.right && player.right > ball.left &&
-            player.top < ball.bottom && player.bottom > ball.top) {
+        if (
+            ((ball.vel.x > 0 && ball.right > player.left && ball.right < player.right) ||
+            (ball.vel.x < 0 && ball.left < player.right && ball.left > player.left)) &&
+            player.top < ball.bottom && player.bottom > ball.top
+        ) {
             ball.vel.x = -ball.vel.x * 1.05;
             const len = ball.vel.len;
             ball.vel.y += player.vel.y * .2;


### PR DESCRIPTION
Change the collision detection so it only detects a collision with the left side of a paddle when traveling right and the right side of a paddle when traveling left. Otherwise occasionally when the length of the vector is adjusted after collision the ball slows down in the x direction and will not far enough to be outside the paddle after the next dt triggering a chain reaction of collisions, direction changes and shortening x velocities.  see issue #1